### PR TITLE
Make compatible with Laravel 5

### DIFF
--- a/src/Dialect/Json.php
+++ b/src/Dialect/Json.php
@@ -25,7 +25,7 @@ trait Json
      */
     public static function bootJson()
     {
-        self::loading(function($obj)
+        self::creating(function($obj)
         {
             $obj->inspectJsonColumns();
         });


### PR DESCRIPTION
The loading event appears to have gone away in L5. I switched to the creating event, which works.
