### PR TITLE
Allow pre-set attributes

### DIFF
--- a/src/Dialect/Json.php
+++ b/src/Dialect/Json.php
@@ -1,5 +1,7 @@
 <?php namespace Eloquent\Dialect;
 
+use stdClass;
+
 trait Json
 {
     /**
@@ -52,6 +54,7 @@ trait Json
                 }
             }
         }
+
     }
 
     /**
@@ -128,7 +131,9 @@ trait Json
 
         if (array_key_exists($key, $this->jsonAttributes) != false) {
             $obj = json_decode($this->{$this->jsonAttributes[$key]});
-            return $obj->$key;
+            if($obj)
+                return $obj->$key;
+            return null;
         } elseif ($isJson) {
             return null;
         }
@@ -165,9 +170,14 @@ trait Json
     public function setJsonAttribute($attribute, $key, $value)
     {
         $obj = json_decode($this->{$attribute});
-        $obj->$key = $value;
-        $this->flagJsonAttribute($key, $attribute);
-        $this->{$attribute} = json_encode($obj);
+        if(!is_object($obj))
+            $obj = new stdClass;
+        // only set this if $value isn't null.
+        if(!is_null($value) ) {
+            $obj->$key = $value;
+            $this->flagJsonAttribute($key, $attribute);
+            $this->{$attribute} = json_encode($obj);
+        }
         return;
     }
 }

--- a/src/Dialect/Json.php
+++ b/src/Dialect/Json.php
@@ -131,8 +131,9 @@ trait Json
 
         if (array_key_exists($key, $this->jsonAttributes) != false) {
             $obj = json_decode($this->{$this->jsonAttributes[$key]});
-            if($obj)
+            if($obj && isset($obj->$key)) {
                 return $obj->$key;
+            }
             return null;
         } elseif ($isJson) {
             return null;

--- a/src/Dialect/Json.php
+++ b/src/Dialect/Json.php
@@ -173,12 +173,10 @@ trait Json
         $obj = json_decode($this->{$attribute});
         if(!is_object($obj))
             $obj = new stdClass;
-        // only set this if $value isn't null.
-        if(!is_null($value) ) {
-            $obj->$key = $value;
-            $this->flagJsonAttribute($key, $attribute);
-            $this->{$attribute} = json_encode($obj);
-        }
+        
+        $obj->$key = $value;
+        $this->flagJsonAttribute($key, $attribute);
+        $this->{$attribute} = json_encode($obj);
         return;
     }
 }


### PR DESCRIPTION
Hello,

I've been using your package and its great.  My fields are dynamically set when the model is constructed like so:

```
    public function __construct(array $attributes = array())
    {
        $defined = $this->getDefinedJsonColumns();
        foreach($defined as $col => $attr){
            foreach($attr as $key){
                $this->flagJsonAttribute($key, $col);
            }
        }
        parent::__construct($attributes);
    }
```

This doesn't work in your current version of dialect b/c the json has to already be in the database.  

This pull request fixes that.
