### PR TITLE
Decode JSON objects in onArray and don't hide them

### DIFF
--- a/src/Dialect/Json.php
+++ b/src/Dialect/Json.php
@@ -34,6 +34,27 @@ trait Json
     }
 
     /**
+     * Converts the model to an array
+     * Overrides parent to decode JSON columns.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $values = parent::toArray();
+
+        foreach ($values as $key=>$value)
+        {
+            if (in_array($key, $this->jsonAttributes))
+            {
+                $values[$key] = json_decode($value);
+            }
+        }
+
+        return $values;
+    }
+    
+    /**
      * Decodes each of the declared JSON attributes and records the attributes
      * on each
      *
@@ -42,7 +63,6 @@ trait Json
     public function inspectJsonColumns()
     {
         foreach ($this->jsonColumns as $col) {
-            $this->hidden[] = $col;
             $obj = json_decode($this->$col);
 
             if (is_object($obj)) {

--- a/src/Dialect/Json.php
+++ b/src/Dialect/Json.php
@@ -43,10 +43,8 @@ trait Json
     {
         $values = parent::toArray();
 
-        foreach ($values as $key=>$value)
-        {
-            if (in_array($key, $this->jsonAttributes))
-            {
+        foreach ($values as $key=>$value) {
+            if (in_array($key, $this->jsonAttributes)) {
                 $values[$key] = json_decode($value);
             }
         }


### PR DESCRIPTION
In my opinion, if you want to hide JSON columns, you can use $hidden for that, so I changed the trait slightly to allow for automatic decoding of JSON objects and removing the automatic hide part.
